### PR TITLE
Replace deprecated Twig_Function_Method by Twig_SimpleFunction

### DIFF
--- a/Twig/StaticExtension.php
+++ b/Twig/StaticExtension.php
@@ -21,7 +21,7 @@ class StaticExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'file' => new \Twig_Function_Method($this, 'file')
+            'file' => new \Twig_SimpleFunction('file', [$this, 'file'])
         );
     }
 


### PR DESCRIPTION
The Twig_Function_Method class is deprecated since version 1.12 and will be removed in 2.0. Use Twig_SimpleFunction instead.
